### PR TITLE
Fix - update notification msg shown after user claims rewards

### DIFF
--- a/src/app/components/home/RewardsPanel.tsx
+++ b/src/app/components/home/RewardsPanel.tsx
@@ -41,6 +41,7 @@ const RewardsPanel = () => {
           { hash: res.result }, //
           {
             summary: `Claimed ${reward.dp(2).toFormat()} BALN.`,
+            pending: "Claiming rewards...",
           },
         );
         toggleOpen();


### PR DESCRIPTION
Issue #323 
Say "Claiming rewards..." instead of "This transaction has been sent to the network" on the notification box.