### PR TITLE
Fix: change risk ratio bar color when passing "All Collateral Locked"

### DIFF
--- a/src/app/components/home/PositionDetailPanel.tsx
+++ b/src/app/components/home/PositionDetailPanel.tsx
@@ -108,6 +108,8 @@ const PositionDetailPanel = () => {
 
   const isLockWarning = lockThresholdPrice.minus(ratio.ICXUSDratio).isGreaterThan(-0.01);
 
+  const isPassAllCollateralLocked = ratio.ICXUSDratio.isLessThan(lockThresholdPrice);
+
   // handle rebalancing logic
   const [anchor, setAnchor] = React.useState<HTMLElement | null>(null);
 
@@ -184,7 +186,9 @@ const PositionDetailPanel = () => {
             <LeftChip
               bg="primary"
               style={{
-                backgroundImage: 'linear-gradient(to right, #2ca9b7 ' + lowRisk1 + '%, #144a68 ' + lowRisk1 + '%)',
+                background: isPassAllCollateralLocked
+                  ? '#fb6a6a'
+                  : 'linear-gradient(to right, #2ca9b7 ' + lowRisk1 + '%, #144a68 ' + lowRisk1 + '%)',
               }}
             >
               Low risk
@@ -222,7 +226,7 @@ const PositionDetailPanel = () => {
               disabled={true}
               id="slider-risk"
               direction="rtl"
-              start={[Math.min(currentRatio.toNumber(), 900)]}
+              start={[Math.min(isPassAllCollateralLocked ? 150 : currentRatio.toNumber(), 900)]}
               connect={[true, false]}
               range={{
                 min: [150],
@@ -233,7 +237,7 @@ const PositionDetailPanel = () => {
                   sliderInstance.current = instance;
                 }
               }}
-              style={{ height: 16 }}
+              style={{ height: 16, backgroundColor: isPassAllCollateralLocked ? '#fb6a6a' : '' }}
             />
           </Box>
 

--- a/src/app/components/home/PositionDetailPanel.tsx
+++ b/src/app/components/home/PositionDetailPanel.tsx
@@ -226,7 +226,7 @@ const PositionDetailPanel = () => {
               disabled={true}
               id="slider-risk"
               direction="rtl"
-              start={[Math.min(isPassAllCollateralLocked ? 150 : currentRatio.toNumber(), 900)]}
+              start={[Math.min(currentRatio.toNumber(), 900)]}
               connect={[true, false]}
               range={{
                 min: [150],


### PR DESCRIPTION
The result after fixed:
![evidence](https://user-images.githubusercontent.com/17588370/126026281-a6b5940a-3f80-4d05-a7ac-4babde96537c.png)
