### PR TITLE
fix: 🐛 can't withdraw all collateral

### DIFF
--- a/src/app/components/home/LoanPanel.tsx
+++ b/src/app/components/home/LoanPanel.tsx
@@ -94,7 +94,8 @@ const LoanPanel = () => {
   //after
   const afterAmount = parsedAmount[Field.LEFT];
   //difference = after-before
-  const differenceAmount = afterAmount.minus(beforeAmount.toFixed(2));
+  const differenceAmount = afterAmount.minus(beforeAmount);
+  const roundedDisplayDiffAmount = afterAmount.minus(beforeAmount.dp(2));
 
   //whether if repay or borrow
   const shouldBorrow = differenceAmount.isPositive();
@@ -321,7 +322,7 @@ const LoanPanel = () => {
           </Typography>
 
           <Typography variant="p" fontWeight="bold" textAlign="center" fontSize={20}>
-            {differenceAmount.dp(2).toFormat()} bnUSD
+            {roundedDisplayDiffAmount.dp(2).toFormat()} bnUSD
           </Typography>
 
           <Flex my={5}>


### PR DESCRIPTION
because when a user repay, the borrowed bnusd is rounded to 2 decimal places, so there still
be very tiny remaining amount 0.000xx left in borrow

that's why you can't withdraw all collateral 

Please repay off the loan again even you see `Borrowed` = 0 to clear the tiny amount , then can withdraw all collateral
