### PR TITLE
sort assets in swap tab from largest amount to smallest amount

### DIFF
--- a/src/app/components/CurrencyInputPanel/index.tsx
+++ b/src/app/components/CurrencyInputPanel/index.tsx
@@ -159,6 +159,9 @@ export default function CurrencyInputPanel({
 
   const balances = useWalletBalances();
   const balanceList1 = balanceList || balances;
+  const sortedTokenList = SUPPORTED_TOKENS_LIST.sort(
+    (ccy1, ccy2) => balanceList1[ccy2?.symbol!]?.dp(2).toNumber() - balanceList1[ccy1?.symbol!]?.dp(2).toNumber(),
+  );
 
   return (
     <InputContainer ref={ref} className={className}>
@@ -175,7 +178,7 @@ export default function CurrencyInputPanel({
                   <HeaderText>Asset</HeaderText>
                   <HeaderText textAlign="right">{balanceList ? 'Balance' : 'Wallet'}</HeaderText>
                 </DashGrid>
-                {SUPPORTED_TOKENS_LIST.map(ccy => (
+                {sortedTokenList.map(ccy => (
                   <ListItem key={ccy.symbol} onClick={handleCurrencySelect(ccy)}>
                     <Flex>
                       <CurrencyLogo currency={ccy} style={{ marginRight: '8px' }} />


### PR DESCRIPTION
Assets are sorted from largest to smallest balance in wallet. Balances are rounded to a 2-digit mantissa before comparison.
Closes #763 
Screenshot: 
<img width="413" alt="Screen Shot 2021-12-12 at 8 11 54 PM" src="https://user-images.githubusercontent.com/11547815/145743706-ca62ac2b-042f-4c41-a692-640aad68dcb5.png">
 