### PR TITLE
build: add commitizen to help create conventional commits

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn run checkTs && lint-staged"
+      "pre-commit": "yarn run checkTs && lint-staged",
+      "prepare-commit-msg": "exec < /dev/tty && git cz --hook || true"
     }
   },
   "jest": {
@@ -163,5 +164,13 @@
       }
     }
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "commitizen": "4.2.4",
+    "cz-conventional-changelog": "3.3.0"
+  },
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  }
 }


### PR DESCRIPTION
Commitizen has been added and hooked into git via husky.

We use [cz-conventional-changelog](https://www.npmjs.com/package/cz-conventional-changelog) adapter. 
We can modify the configuration through package.json to change settings such as max lengths, capitalization, etc...

To use Commitizen, first install dependencies. Then simply type `git commit`. This will prompt the dev
for info in order to generate a commit message.

Another option is [this](https://github.com/streamich/git-cz), which allows emojis.
Resolves #460