### PR TITLE
fix: Copy changes for currency search placeholder

### DIFF
--- a/src/app/components/SearchModal/CurrencySearch.tsx
+++ b/src/app/components/SearchModal/CurrencySearch.tsx
@@ -5,6 +5,7 @@ import { Flex } from 'rebass/styled-components';
 import styled from 'styled-components';
 
 import { Typography } from 'app/theme';
+import { i18nStrings } from 'constants/i18n';
 import { useICX } from 'constants/tokens';
 import { useAllTokens, useCommonBases, useIsUserAddedToken, useToken } from 'hooks/Tokens';
 import useDebounce from 'hooks/useDebounce';
@@ -36,6 +37,10 @@ interface CurrencySearchProps {
   width?: number;
   balanceList?: { [key: string]: BigNumber };
 }
+
+const {
+  currencySearch: { searchPlaceholder },
+} = i18nStrings;
 
 export function CurrencySearch({
   selectedCurrency,
@@ -122,7 +127,7 @@ export function CurrencySearch({
         <SearchInput
           type="text"
           id="token-search-input"
-          placeholder={`Search name or paste address`}
+          placeholder={searchPlaceholder}
           autoComplete="off"
           value={searchQuery}
           ref={inputRef as RefObject<HTMLInputElement>}

--- a/src/constants/i18n.ts
+++ b/src/constants/i18n.ts
@@ -1,0 +1,5 @@
+export const i18nStrings = {
+  currencySearch: {
+    searchPlaceholder: `Search name or contract`,
+  },
+};


### PR DESCRIPTION
Subsituted placeholder text to reflect mocks. Also, added i18n for
future locatization. Eventually, all visible text should be moved
to this file.

Fixes text cutoff in #807

Web
![Screen Shot 2021-12-17 at 6 14 03 PM](https://user-images.githubusercontent.com/11547815/146621688-1d938a95-fab6-41bb-b396-08ca4549bef5.png)

Mobile
![Screen Shot 2021-12-17 at 6 14 22 PM](https://user-images.githubusercontent.com/11547815/146621698-1a7dd712-54c2-4fcd-98db-be2e44c3ab7a.png)

