### PR TITLE
fix: Align dropdown icons

### DIFF
--- a/src/app/components/CurrencyInputPanel/index.tsx
+++ b/src/app/components/CurrencyInputPanel/index.tsx
@@ -42,7 +42,7 @@ const CurrencySelect = styled.button<{ bg?: string; disabled?: boolean }>`
 
 const StyledTokenName = styled.span`
   line-height: 1.5;
-  margin-right: 8px;
+  margin-right: auto;
   font-size: 14px;
   font-weight: bold;
 `;


### PR DESCRIPTION
Dropdown icons in swap and supply liquidity panels have been right aligned.
resolves #836
![Screen Shot 2022-01-06 at 10 25 09 PM](https://user-images.githubusercontent.com/11547815/148491863-cd2bee12-f05d-41ab-bebd-0cbeaa5a5bda.png)
![Screen Shot 2022-01-06 at 10 24 57 PM](https://user-images.githubusercontent.com/11547815/148491866-c848918a-30a7-42fc-8151-203f65836d4d.png)

