### PR TITLE
fix: Round network fees to two decimals.

### DIFF
--- a/src/app/components/home/RewardsPanel.tsx
+++ b/src/app/components/home/RewardsPanel.tsx
@@ -277,7 +277,7 @@ const NetworkFeeSection = () => {
               .filter(key => fees[key].greaterThan(0))
               .map(key => (
                 <Typography key={key} variant="p">
-                  {`${fees[key].toSignificant(2)}`}{' '}
+                  {`${fees[key].toFixed(2)}`}{' '}
                   <Typography key={key} as="span" color="text1">
                     {fees[key].currency.symbol}
                   </Typography>
@@ -318,7 +318,7 @@ const NetworkFeeSection = () => {
                 .filter(key => fees[key].greaterThan(0))
                 .map(key => (
                   <Typography key={key} variant="p">
-                    {`${fees[key].toSignificant()}`}{' '}
+                    {`${fees[key].toFixed(2)}`}{' '}
                     <Typography key={key} as="span" color="text1">
                       {fees[key].currency.symbol}
                     </Typography>


### PR DESCRIPTION
Fees were display incorrectly. Originally, they were rounded to two signifcant figures
instead of two decimals.

Current:
![Screen Shot 2022-01-13 at 6 16 56 PM](https://user-images.githubusercontent.com/11547815/149430622-7c09cc69-1370-47f9-b090-17ed7125586e.png)

Fix:
![Screen Shot 2022-01-13 at 6 18 32 PM](https://user-images.githubusercontent.com/11547815/149430656-9f8595ca-42db-48c0-aea8-e01a7a5bb39c.png)
![Screen Shot 2022-01-13 at 6 18 37 PM](https://user-images.githubusercontent.com/11547815/149430662-8f23fad9-ba3d-494c-8785-771a7290d86b.png)


Resolves #848 