### PR TITLE
fix: Show balance for BALN in wallet view

### DIFF
--- a/src/app/components/home/WalletPanel.tsx
+++ b/src/app/components/home/WalletPanel.tsx
@@ -82,7 +82,9 @@ const WalletPanel = () => {
           <List>
             <Accordion collapsible>
               {ADDRESSES.filter(address => {
-                if (address === balnAddress && totalBALN.dp(2).isZero()) return false;
+                if (address === balnAddress) {
+                  return !totalBALN.dp(2).isZero();
+                }
                 return !isDPZeroCA(balances[address], 2);
               }).map((address, index, arr) => {
                 const currency = balances[address].currency;

--- a/src/store/wallet/hooks.ts
+++ b/src/store/wallet/hooks.ts
@@ -43,8 +43,9 @@ export function useAvailableBalances(
   return React.useMemo(() => {
     return balances.reduce((acc, balance) => {
       if (!balance) return acc;
-      if (!JSBI.greaterThan(balance.quotient, BIGINT_ZERO)) return acc;
-
+      if (!JSBI.greaterThan(balance.quotient, BIGINT_ZERO) && balance.currency.wrapped.address !== bnJs.BALN.address) {
+        return acc;
+      }
       acc[balance.currency.wrapped.address] = balance;
 
       return acc;


### PR DESCRIPTION
BALN balance will be shown if balance exists.

With Staked BALN:
<img width="538" alt="Screen Shot 2022-02-27 at 9 05 18 PM" src="https://user-images.githubusercontent.com/11547815/155917809-dd1602f5-53d8-43f6-a231-e3c88de73a14.png">

Without BALN
<img width="547" alt="Screen Shot 2022-02-27 at 9 05 41 PM" src="https://user-images.githubusercontent.com/11547815/155917826-6e9d8b99-8a86-4724-8f86-5d5ff203d80d.png">

Without any assets
<img width="547" alt="Screen Shot 2022-02-27 at 9 06 56 PM" src="https://user-images.githubusercontent.com/11547815/155917847-9208c0cb-0bcb-45f5-9bc0-c92ba73065e3.png">

partly fixes #906