### PR TITLE
Fix: ts error - remove dead code - queueRate

### DIFF
--- a/src/types/balanced-v1-sdk/entities/route.ts
+++ b/src/types/balanced-v1-sdk/entities/route.ts
@@ -44,47 +44,11 @@ export class Route<TInput extends Currency, TOutput extends Currency> {
     const prices: Price<Currency, Currency>[] = [];
     /* @ts-ignore */
     for (const [i, pair] of this.pairs.entries()) {
-      if (pair.queueRate) {
-        if (this.path[i].symbol === 'sICX') {
-          prices.push(
-            this.path[i].equals(pair.token0)
-              ? new Price(
-                  pair.reserve0.currency,
-                  pair.reserve1.currency,
-                  pair.queueRate.denominator,
-                  pair.queueRate.numerator,
-                )
-              : new Price(
-                  pair.reserve1.currency,
-                  pair.reserve0.currency,
-                  pair.queueRate.denominator,
-                  pair.queueRate.numerator,
-                ),
-          );
-        } else {
-          prices.push(
-            this.path[i].equals(pair.token0)
-              ? new Price(
-                  pair.reserve0.currency,
-                  pair.reserve1.currency,
-                  pair.queueRate.numerator,
-                  pair.queueRate.denominator,
-                )
-              : new Price(
-                  pair.reserve1.currency,
-                  pair.reserve0.currency,
-                  pair.queueRate.numerator,
-                  pair.queueRate.denominator,
-                ),
-          );
-        }
-      } else {
-        prices.push(
-          this.path[i].equals(pair.token0)
-            ? new Price(pair.reserve0.currency, pair.reserve1.currency, pair.reserve0.quotient, pair.reserve1.quotient)
-            : new Price(pair.reserve1.currency, pair.reserve0.currency, pair.reserve1.quotient, pair.reserve0.quotient),
-        );
-      }
+      prices.push(
+        this.path[i].equals(pair.token0)
+          ? new Price(pair.reserve0.currency, pair.reserve1.currency, pair.reserve0.quotient, pair.reserve1.quotient)
+          : new Price(pair.reserve1.currency, pair.reserve0.currency, pair.reserve1.quotient, pair.reserve0.quotient),
+      );
     }
     const reduced = prices
       .slice(1)


### PR DESCRIPTION
Pairs use reserves to determine price.
For the queue pair, it gets the reserves info from `Dex::getPoolStats` (there's `price`, `total_supply`).
For others, it gets from `Dex::getPoolStatsForPair` (there's `base`, `quote`).